### PR TITLE
Accumulate PartialResultSet objects into ResultSet

### DIFF
--- a/src/main/java/com/google/spannerclient/PartialResultSetCombiner.java
+++ b/src/main/java/com/google/spannerclient/PartialResultSetCombiner.java
@@ -15,8 +15,13 @@
  */
 package com.google.spannerclient;
 
+import com.google.protobuf.ListValue;
+import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
 import com.google.spanner.v1.PartialResultSet;
+import com.google.spanner.v1.ResultSet;
+import java.util.List;
+import java.util.Map;
 
 // TODO(pdex): consider using the builder pattern here
 class PartialResultSetCombiner {
@@ -32,5 +37,141 @@ class PartialResultSetCombiner {
       combined.setChunkedValue(b.getChunkedValue());
     }
     return combined.build();
+  }
+
+  public static void appendToList(ListValue.Builder into, ListValue from, int start) {
+    assert start <= from.getValuesCount();
+    for (int i = start; i < from.getValuesCount(); i++) {
+      into.addValues(from.getValues(i));
+    }
+  }
+
+  public static void mergeChunk(ListValue.Builder chunkedValue, ListValue value) {
+    if (value.getValuesCount() == 0) {
+      return;
+    }
+
+    if (chunkedValue.getValuesCount() == 0) {
+      chunkedValue.addAllValues(value.getValuesList());
+      return;
+    }
+
+    Value.Builder lastValue = chunkedValue.getValuesBuilder(chunkedValue.getValuesCount() - 1);
+    if (lastValue.getKindCase() != value.getValues(0).getKindCase()) {
+      appendToList(chunkedValue, value, 0);
+    } else if (value.getValues(0).getKindCase() == Value.KindCase.LIST_VALUE) {
+      // [['a', 'b']]
+      //      +
+      // [['c', 'd']]
+      //      =
+      // [['a', 'bc', 'd']]
+      mergeChunk(lastValue.getListValueBuilder(), value.getValues(0).getListValue());
+      appendToList(chunkedValue, value, 1);
+    } else if (value.getValues(0).getKindCase() == Value.KindCase.STRING_VALUE) {
+      // ['a', 'b']
+      //     +
+      // ['c', 'd']
+      //     =
+      // ['a', 'bc', 'd']
+      lastValue.setStringValue(
+          lastValue.getStringValue().concat(value.getValues(0).getStringValue()));
+      appendToList(chunkedValue, value, 1);
+    } else {
+      appendToList(chunkedValue, value, 0);
+    }
+  }
+
+  public static void mergeChunk(Struct.Builder chunkedValue, Struct value) {
+    if (value.getFieldsCount() == 0) {
+      return;
+    }
+
+    if (chunkedValue.getFieldsCount() == 0) {
+      chunkedValue.putAllFields(value.getFieldsMap());
+      return;
+    }
+
+    for (Map.Entry<String, Value> entry : value.getFieldsMap().entrySet()) {
+      if (chunkedValue.containsFields(entry.getKey())) {
+        // key already exists in chunk append v to existing kv pair
+        Value.Builder existing = chunkedValue.getFieldsOrThrow(entry.getKey()).toBuilder();
+        if (existing.getKindCase() != entry.getValue().getKindCase()) {
+          // error condition?
+        } else if (existing.getKindCase() == Value.KindCase.LIST_VALUE) {
+          mergeChunk(existing.getListValueBuilder(), entry.getValue().getListValue());
+        } else if (existing.getKindCase() == Value.KindCase.STRING_VALUE) {
+          existing.setStringValue(
+              existing.getStringValue().concat(entry.getValue().getStringValue()));
+        } else if (existing.getKindCase() == Value.KindCase.STRUCT_VALUE) {
+          mergeChunk(existing.getStructValueBuilder(), entry.getValue().getStructValue());
+        }
+        chunkedValue.putFields(entry.getKey(), existing.build());
+      } else {
+        // key doesn't exist in chunk put kv pair
+        chunkedValue.putFields(entry.getKey(), entry.getValue());
+      }
+    }
+  }
+
+  public static ResultSet combine(List<PartialResultSet> partials) {
+    return combine(partials, 1, 0);
+  }
+
+  public static ResultSet combine(
+      List<PartialResultSet> resultSet, int columnsPerRow, int startIndex) {
+    ResultSet.Builder out = ResultSet.newBuilder();
+    ListValue.Builder currentRow = null;
+    Value.Builder chunkedValue = Value.newBuilder();
+    for (int i = startIndex; i < resultSet.size(); i++) {
+      PartialResultSet part = resultSet.get(i);
+      if (part.hasMetadata()) {
+        out.setMetadata(part.getMetadata());
+      }
+      if (part.hasStats()) {
+        out.setStats(part.getStats());
+      }
+      for (int idx = 0; idx < part.getValuesCount(); idx++) {
+        Value value = part.getValues(idx);
+        // only the last value may be chunked
+        // accumulate chunks into chunkedValue
+        if (part.getChunkedValue() && idx == part.getValuesCount() - 1) {
+          if (value.hasListValue()) {
+            assert value.getListValue().getValuesCount() > 0;
+            mergeChunk(chunkedValue.getListValueBuilder(), value.getListValue());
+          } else if (value.hasStructValue()) {
+            assert value.getStructValue().getFieldsCount() > 0;
+            mergeChunk(chunkedValue.getStructValueBuilder(), value.getStructValue());
+          } else {
+            assert value.getKindCase() == Value.KindCase.STRING_VALUE;
+            chunkedValue.setStringValue(
+                chunkedValue.getStringValue().concat(value.getStringValue()));
+          }
+        } else {
+          if (currentRow == null || currentRow.getValuesCount() == columnsPerRow) {
+            currentRow = out.addRowsBuilder();
+          }
+          // first value in a parts list must be merged with the chunk
+          if (chunkedValue.getKindCase() != Value.KindCase.KIND_NOT_SET) {
+            assert idx == 0;
+            if (chunkedValue.hasListValue()) {
+              assert value.getListValue().getValuesCount() > 0;
+              mergeChunk(chunkedValue.getListValueBuilder(), value.getListValue());
+            } else if (chunkedValue.hasStructValue()) {
+              assert value.getStructValue().getFieldsCount() > 0;
+              mergeChunk(chunkedValue.getStructValueBuilder(), value.getStructValue());
+            } else {
+              assert value.getKindCase() == Value.KindCase.STRING_VALUE;
+              chunkedValue.setStringValue(
+                  chunkedValue.getStringValue().concat(value.getStringValue()));
+            }
+            currentRow.addValues(chunkedValue);
+            chunkedValue.clear();
+          } else {
+            currentRow.addValues(value);
+          }
+        }
+      }
+    }
+    return out.build();
   }
 }

--- a/src/test/java/com/google/spannerclient/PartialResultSetCombinerTests.java
+++ b/src/test/java/com/google/spannerclient/PartialResultSetCombinerTests.java
@@ -17,14 +17,22 @@ package com.google.spannerclient;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.google.protobuf.ListValue;
+import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
 import com.google.spanner.v1.PartialResultSet;
+import com.google.spanner.v1.ResultSet;
+import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 class PartialResultSetCombinerTests {
 
   @Test
   void stringCombine() {
+    /*
+    # Strings are concatenated.
+    "foo", "bar" => "foobar"
+        */
     PartialResultSet a =
         PartialResultSet.newBuilder()
             .addValues(Value.newBuilder().setStringValue("foo").build())
@@ -35,9 +43,300 @@ class PartialResultSetCombinerTests {
             .addValues(Value.newBuilder().setStringValue("bar").build())
             .setChunkedValue(false)
             .build();
-    PartialResultSet r = PartialResultSetCombiner.combine(a, b);
+    ResultSet r = PartialResultSetCombiner.combine(Arrays.asList(a, b));
 
-    assertEquals("foobar", r.getValues(0).getStringValue());
-    assertEquals(false, r.getChunkedValue());
+    assertEquals("foobar", r.getRows(0).getValues(0).getStringValue());
+  }
+
+  @Test
+  void integerCombine() {
+    /*
+    # Lists of non-strings are concatenated.
+    [2, 3], [4] => [2, 3, 4]
+        */
+    PartialResultSet a =
+        PartialResultSet.newBuilder()
+            .addValues(
+                Value.newBuilder()
+                    .setListValue(
+                        ListValue.newBuilder()
+                            .addValues(Value.newBuilder().setNumberValue(2))
+                            .addValues(Value.newBuilder().setNumberValue(3))))
+            .setChunkedValue(true)
+            .build();
+    PartialResultSet b =
+        PartialResultSet.newBuilder()
+            .addValues(
+                Value.newBuilder()
+                    .setListValue(
+                        ListValue.newBuilder().addValues(Value.newBuilder().setNumberValue(4))))
+            .setChunkedValue(false)
+            .build();
+    ResultSet r = PartialResultSetCombiner.combine(Arrays.asList(a, b));
+    assertEquals(
+        ListValue.newBuilder()
+            .addValues(Value.newBuilder().setNumberValue(2))
+            .addValues(Value.newBuilder().setNumberValue(3))
+            .addValues(Value.newBuilder().setNumberValue(4))
+            .build(),
+        r.getRows(0).getValues(0).getListValue());
+  }
+
+  @Test
+  void stringListCombine() {
+    /*
+    # Lists are concatenated, but the last and first elements are merged
+    # because they are strings.
+    ["a", "b"], ["c", "d"] => ["a", "bc", "d"]
+        */
+    PartialResultSet a =
+        PartialResultSet.newBuilder()
+            .addValues(
+                Value.newBuilder()
+                    .setListValue(
+                        ListValue.newBuilder()
+                            .addValues(Value.newBuilder().setStringValue("a"))
+                            .addValues(Value.newBuilder().setStringValue("b"))))
+            .setChunkedValue(true)
+            .build();
+    PartialResultSet b =
+        PartialResultSet.newBuilder()
+            .addValues(
+                Value.newBuilder()
+                    .setListValue(
+                        ListValue.newBuilder()
+                            .addValues(Value.newBuilder().setStringValue("c"))
+                            .addValues(Value.newBuilder().setStringValue("d"))))
+            .setChunkedValue(false)
+            .build();
+    ResultSet r = PartialResultSetCombiner.combine(Arrays.asList(a, b));
+    assertEquals(
+        ListValue.newBuilder()
+            .addValues(Value.newBuilder().setStringValue("a"))
+            .addValues(Value.newBuilder().setStringValue("bc"))
+            .addValues(Value.newBuilder().setStringValue("d"))
+            .build(),
+        r.getRows(0).getValues(0).getListValue());
+  }
+
+  @Test
+  void stringListAndSublistCombine() {
+    /*
+    # Lists are concatenated, but the last and first elements are merged
+    # because they are lists. Recursively, the last and first elements
+    # of the inner lists are merged because they are strings.
+    ["a", ["b", "c"]], [["d"], "e"] => ["a", ["b", "cd"], "e"]
+        */
+    PartialResultSet a =
+        PartialResultSet.newBuilder()
+            .addValues(
+                Value.newBuilder()
+                    .setListValue(
+                        ListValue.newBuilder()
+                            .addValues(Value.newBuilder().setStringValue("a"))
+                            .addValues(
+                                Value.newBuilder()
+                                    .setListValue(
+                                        ListValue.newBuilder()
+                                            .addValues(Value.newBuilder().setStringValue("b"))
+                                            .addValues(Value.newBuilder().setStringValue("c"))))))
+            .setChunkedValue(true)
+            .build();
+    PartialResultSet b =
+        PartialResultSet.newBuilder()
+            .addValues(
+                Value.newBuilder()
+                    .setListValue(
+                        ListValue.newBuilder()
+                            .addValues(
+                                Value.newBuilder()
+                                    .setListValue(
+                                        ListValue.newBuilder()
+                                            .addValues(Value.newBuilder().setStringValue("d"))))
+                            .addValues(Value.newBuilder().setStringValue("e"))))
+            .setChunkedValue(false)
+            .build();
+    ResultSet r = PartialResultSetCombiner.combine(Arrays.asList(a, b));
+    assertEquals(
+        ListValue.newBuilder()
+            .addValues(Value.newBuilder().setStringValue("a"))
+            .addValues(
+                Value.newBuilder()
+                    .setListValue(
+                        ListValue.newBuilder()
+                            .addValues(Value.newBuilder().setStringValue("b"))
+                            .addValues(Value.newBuilder().setStringValue("cd"))))
+            .addValues(Value.newBuilder().setStringValue("e"))
+            .build(),
+        r.getRows(0).getValues(0).getListValue());
+  }
+
+  @Test
+  void objectFieldsCombine() {
+    /*
+    # Non-overlapping object fields are combined.
+    {"a": "1"}, {"b": "2"} => {"a": "1", "b": 2"}
+        */
+    PartialResultSet a =
+        PartialResultSet.newBuilder()
+            .addValues(
+                Value.newBuilder()
+                    .setStructValue(
+                        Struct.newBuilder()
+                            .putFields("a", Value.newBuilder().setStringValue("1").build())))
+            .setChunkedValue(true)
+            .build();
+    PartialResultSet b =
+        PartialResultSet.newBuilder()
+            .addValues(
+                Value.newBuilder()
+                    .setStructValue(
+                        Struct.newBuilder()
+                            .putFields("b", Value.newBuilder().setStringValue("2").build())))
+            .setChunkedValue(false)
+            .build();
+    ResultSet r = PartialResultSetCombiner.combine(Arrays.asList(a, b));
+    assertEquals(
+        Struct.newBuilder()
+            .putFields("a", Value.newBuilder().setStringValue("1").build())
+            .putFields("b", Value.newBuilder().setStringValue("2").build())
+            .build(),
+        r.getRows(0).getValues(0).getStructValue());
+  }
+
+  @Test
+  void objectFieldsOverlappingCombine() {
+    /*
+    # Overlapping object fields are merged.
+    {"a": "1"}, {"a": "2"} => {"a": "12"}
+        */
+    PartialResultSet a =
+        PartialResultSet.newBuilder()
+            .addValues(
+                Value.newBuilder()
+                    .setStructValue(
+                        Struct.newBuilder()
+                            .putFields("a", Value.newBuilder().setStringValue("1").build())))
+            .setChunkedValue(true)
+            .build();
+    PartialResultSet b =
+        PartialResultSet.newBuilder()
+            .addValues(
+                Value.newBuilder()
+                    .setStructValue(
+                        Struct.newBuilder()
+                            .putFields("a", Value.newBuilder().setStringValue("2").build())))
+            .setChunkedValue(false)
+            .build();
+    ResultSet r = PartialResultSetCombiner.combine(Arrays.asList(a, b));
+    assertEquals(
+        Struct.newBuilder().putFields("a", Value.newBuilder().setStringValue("12").build()).build(),
+        r.getRows(0).getValues(0).getStructValue());
+  }
+
+  @Test
+  void objectFieldsOverlappingSublistCombine() {
+    /*
+    # Examples of merging objects containing lists of strings.
+    {"a": ["1"]}, {"a": ["2"]} => {"a": ["12"]}
+        */
+    PartialResultSet a =
+        PartialResultSet.newBuilder()
+            .addValues(
+                Value.newBuilder()
+                    .setStructValue(
+                        Struct.newBuilder()
+                            .putFields(
+                                "a",
+                                Value.newBuilder()
+                                    .setListValue(
+                                        ListValue.newBuilder()
+                                            .addValues(Value.newBuilder().setStringValue("1")))
+                                    .build())))
+            .setChunkedValue(true)
+            .build();
+    PartialResultSet b =
+        PartialResultSet.newBuilder()
+            .addValues(
+                Value.newBuilder()
+                    .setStructValue(
+                        Struct.newBuilder()
+                            .putFields(
+                                "a",
+                                Value.newBuilder()
+                                    .setListValue(
+                                        ListValue.newBuilder()
+                                            .addValues(Value.newBuilder().setStringValue("2")))
+                                    .build())))
+            .setChunkedValue(false)
+            .build();
+    ResultSet r = PartialResultSetCombiner.combine(Arrays.asList(a, b));
+    assertEquals(
+        Struct.newBuilder()
+            .putFields(
+                "a",
+                Value.newBuilder()
+                    .setListValue(
+                        ListValue.newBuilder().addValues(Value.newBuilder().setStringValue("12")))
+                    .build())
+            .build(),
+        r.getRows(0).getValues(0).getStructValue());
+  }
+
+  @Test
+  void aMoreCompleteExampleCombine() {
+    /*
+    For a more complete example, suppose a streaming SQL query is yielding a result set whose rows contain a single string field. The following PartialResultSets might be yielded:
+
+    {
+      "metadata": { ... }
+      "values": ["Hello", "W"]
+      "chunkedValue": true
+      "resumeToken": "Af65..."
+    }
+    {
+      "values": ["orl"]
+      "chunkedValue": true
+      "resumeToken": "Bqp2..."
+    }
+    {
+      "values": ["d"]
+      "resumeToken": "Zx1B..."
+    }
+    This sequence of PartialResultSets encodes two rows, one containing the field value "Hello", and a second containing the field value "World" = "W" + "orl" + "d".
+        */
+    PartialResultSet a =
+        PartialResultSet.newBuilder()
+            .addValues(
+                Value.newBuilder()
+                    .setListValue(
+                        ListValue.newBuilder()
+                            .addValues(Value.newBuilder().setStringValue("Hello"))
+                            .addValues(Value.newBuilder().setStringValue("W"))))
+            .setChunkedValue(true)
+            .build();
+    PartialResultSet b =
+        PartialResultSet.newBuilder()
+            .addValues(
+                Value.newBuilder()
+                    .setListValue(
+                        ListValue.newBuilder().addValues(Value.newBuilder().setStringValue("orl"))))
+            .setChunkedValue(true)
+            .build();
+    PartialResultSet c =
+        PartialResultSet.newBuilder()
+            .addValues(
+                Value.newBuilder()
+                    .setListValue(
+                        ListValue.newBuilder().addValues(Value.newBuilder().setStringValue("d"))))
+            .setChunkedValue(false)
+            .build();
+    ResultSet r = PartialResultSetCombiner.combine(Arrays.asList(a, b, c));
+    assertEquals(
+        ListValue.newBuilder()
+            .addValues(Value.newBuilder().setStringValue("Hello"))
+            .addValues(Value.newBuilder().setStringValue("World"))
+            .build(),
+        r.getRows(0).getValues(0).getListValue());
   }
 }


### PR DESCRIPTION
This is the first pass attempt at getting this to work.
All of the examples from
https://cloud.google.com/spanner/docs/reference/rest/v1/PartialResultSet
have been translated into unit tests. All tests are passing.